### PR TITLE
SEO fixes

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -6,6 +6,15 @@
 		<meta name="description" content="{{ description or metadata.description }}">
 		<meta name="generator" content="{{ eleventy.generator }}">
 		<link rel="icon" type="image/x-icon" href="/assets/favicon.ico">
+
+		<link rel="alternate" type="application/atom+xml" href="/feed.xml" title="{{ metadata.title }}">
+		<link rel="canonical" href="{{ metadata.url }}{{ page.url }}">
+		<meta property="og:title" content="{{ title or metadata.title }}">
+		<meta property="og:description" content="{{ description or metadata.description }}">
+		<meta property="og:url" content="{{ metadata.url }}{{ page.url }}">
+		<meta property="og:type" content="{{ 'article' if 'posts' in (tags or []) else 'website' }}">
+		<meta name="twitter:card" content="summary">
+
 		<title>
 			{% if title %}{{ title }} - {% endif %}{{ metadata.title }}
 		</title>

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -2,6 +2,23 @@
 layout: layouts/base.njk
 ---
 
+<script type="application/ld+json">
+{
+	"@context": "https://schema.org",
+	"@type": "BlogPosting",
+	"headline": {{ title | dump }},
+	"datePublished": "{{ date | htmlDateString }}",
+	"dateModified": "{{ date | htmlDateString }}",
+	"description": {{ (description or "") | dump }},
+	"url": "{{ metadata.url }}{{ page.url }}",
+	"author": {
+		"@type": "Person",
+		"name": {{ metadata.author.name | dump }},
+		"url": {{ metadata.author.url | dump }}
+	}
+}
+</script>
+
 {# Only include the syntax highlighter CSS on blog posts, included with the CSS per-page bundle. #}
 {# Capture the CSS content as a Nunjucks variable and feed it through to the cssmin filter to minify it. #}
 {% set css %}

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -3,3 +3,5 @@ Disallow:
 
 User-agent: GPTBot
 Disallow: /
+
+Sitemap: https://fedknu.com/sitemap.xml

--- a/content/sitemap.njk
+++ b/content/sitemap.njk
@@ -1,0 +1,15 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	{%- for entry in collections.all %}
+		{%- if not entry.data.draft and entry.url != "/sitemap.xml" %}
+	<url>
+		<loc>{{ metadata.url }}{{ entry.url }}</loc>
+		<lastmod>{{ entry.date | htmlDateString }}</lastmod>
+	</url>
+		{%- endif %}
+	{%- endfor %}
+</urlset>

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -50,7 +50,13 @@ export default function (eleventyConfig) {
 			name: "posts", // iterate over `collections.posts`
 			limit: 0 // no limit
 		},
-		metadata
+		metadata: {
+			language: metadata.language,
+			title: metadata.title,
+			subtitle: metadata.description,
+			base: metadata.url,
+			author: metadata.author
+		}
 	});
 
 	// Image plugin


### PR DESCRIPTION
## 1. Broken feed (`eleventy.config.js`)

The feed plugin expects `base` (not `url`) and `subtitle` (not `description`). The metadata object is passed directly but the field names don't match, so the plugin falls back to example.com defaults. Fixing this by passing a remapped object.

## 2. Feed autodiscovery (`_includes/layouts/base.njk`)

Add `<link rel="alternate" type="application/atom+xml" href="/feed.xml" title="{{ metadata.title }}">` inside `<head>`.

## 3. Canonical link (`_includes/layouts/base.njk`)

Add `<link rel="canonical" href="{{ metadata.url }}{{ page.url }}">` inside `<head>`.

## 4. Open Graph tags (`_includes/layouts/base.njk`)

Add `og:title`, `og:description`, `og:url`, `og:type` (using `'article' if 'posts' in (tags or []) else 'website'`), and `twitter:card`. No `og:image` since the blog has no featured images. Adding a broken or generic image would be worse than omitting it.

## 5. JSON-LD structured data (`_includes/layouts/post.njk`)

Add a BlogPosting schema block in a `<script type="application/ld+json">` tag using `title`, `date`, `description`, `page.url`, and `metadata.author`.

## 6. Sitemap (`content/sitemap.njk`)

Create a new Nunjucks template with permalink: `/sitemap.xml` that iterates over `collections.all`, skips drafts and the sitemap page itself, and emits standard `<url>` entries.

## 7. robots.txt (assets/robots.txt)

Add sitemap: https://fedknu.com/sitemap.xml.