### PR TITLE
A11y fixes

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -42,10 +42,10 @@
 				<a href="/" class="layout-header__site-name__link common-focus-ring">
 					<img class="layout-header__site-name__emoji" src="/assets/engineer.svg" alt="" eleventy:ignore/>
 					<span class="layout-header__site-name__container">
-						<span class="layout-header__site-name__title">
+						<div class="layout-header__site-name__title">
 							F. Knüssel<span class="visually-hidden">: </span>
-						</span>
-						<span class="layout-header__site-name__tagline">Frontend Developer</span>
+						</div>
+						<div class="layout-header__site-name__tagline">Frontend Developer</div>
 					</span>
 				</a>
 

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -38,22 +38,25 @@
       	</a>
 
 		<header class="layout-header">
-			<nav class="layout-header__navigation">
+			<nav class="layout-header__navigation" aria-label="Site">
 				<a href="/" class="layout-header__site-name__link common-focus-ring">
 					<img class="layout-header__site-name__emoji" src="/assets/engineer.svg" alt="" eleventy:ignore/>
 					<span class="layout-header__site-name__container">
-						<div class="layout-header__site-name__title">
-              				F. Knüssel<span class="visually-hidden">: </span>
-						</div>
-						<div class="layout-header__site-name__tagline">Frontend Developer</div>
+						<span class="layout-header__site-name__title">
+							F. Knüssel<span class="visually-hidden">: </span>
+						</span>
+						<span class="layout-header__site-name__tagline">Frontend Developer</span>
 					</span>
 				</a>
 
 				<ul class="layout-header__navigation__list">
 					{%- for entry in collections.all | eleventyNavigation %}
 						<li class="layout-header__navigation__list-item">
-							<a href="{{entry.url}}" class="layout-header__navigation__link common-focus-ring {{ 'layout-header__navigation__link--active' if entry.url == page.url }}">
-								{{ entry.key }}
+							<a href="{{entry.url}}"
+							   class="layout-header__navigation__link common-focus-ring {{ 'layout-header__navigation__link--active' if entry.url == page.url }}"
+							   {% if entry.url == page.url %}aria-current="page"{% endif %}
+							   {% if 'http' in entry.url %}target="_blank" rel="noopener noreferrer"{% endif %}>
+								{{ entry.key }}{% if 'http' in entry.url %}<span class="visually-hidden"> (external link)</span>{% endif %}
 							</a>
 						</li>
 					{%- endfor %}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -55,8 +55,8 @@
 							<a href="{{entry.url}}"
 							   class="layout-header__navigation__link common-focus-ring {{ 'layout-header__navigation__link--active' if entry.url == page.url }}"
 							   {% if entry.url == page.url %}aria-current="page"{% endif %}
-							   {% if 'http' in entry.url %}target="_blank" rel="noopener noreferrer"{% endif %}>
-								{{ entry.key }}{% if 'http' in entry.url %}<span class="visually-hidden"> (external link)</span>{% endif %}
+							   {% if entry.url.startsWith('http') %}target="_blank" rel="noopener noreferrer"{% endif %}>
+								{{ entry.key }}{% if entry.url.startsWith('http') %}<span class="visually-hidden"> (external link)</span>{% endif %}
 							</a>
 						</li>
 					{%- endfor %}

--- a/_includes/layouts/page.njk
+++ b/_includes/layouts/page.njk
@@ -2,12 +2,10 @@
 layout: layouts/base.njk
 ---
 
-<article>
-	<h1 class="common-main-title">
-		{{ (heading or title) | safe }}
-	</h1>
+<h1 class="common-main-title">
+	{{ heading or title }}
+</h1>
 
-	<div class="common-main-content">
-		{{ content | safe }}
-	</div>
-</article>
+<div class="common-main-content">
+	{{ content | safe }}
+</div>

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -31,13 +31,13 @@ layout: layouts/base.njk
 
 <article>
 	<header class="blog-post__header">
-		<h1 class="common-main-title">{{ title | safe }}</h1>
+		<h1 class="common-main-title">{{ title }}</h1>
 		<div class="blog-post__metadata">
-			<time datetime="{{ date | htmlDateString | safe }}" class="blog-post__metadata__date">
-				{{ date | readableDate | safe }}
+			<time datetime="{{ date | htmlDateString }}" class="blog-post__metadata__date">
+				{{ date | readableDate }}
 			</time>
 			<span class="blog-post__metadata__tags">
-				{{ tags | readableTags | join(", ") | safe }}
+				{{ tags | readableTags | join(", ") }}
 			</span>
 		</div>
 	</header>

--- a/_includes/styles/common.css
+++ b/_includes/styles/common.css
@@ -53,12 +53,6 @@
 	border-bottom-style: none;
 }
 
-.common-link:visited,
-.common-main-content a:visited {
-	border-bottom-color: var(--token-color-gray-medium);
-	color: var(--token-color-gray-medium);
-}
-
 /* Headings */
 .common-main-content h1 {
 	/* There shouldn't be any other headings level 1 in an article/page */

--- a/_includes/styles/common.css
+++ b/_includes/styles/common.css
@@ -119,7 +119,7 @@
 	font-size: var(--token-font-size-sm);
 	margin: 0;
 	padding: var(--token-spacing-xxs) var(--token-spacing-xs);
-	white-space: nowrap;
+	overflow-wrap: break-word;
 	color: var(--token-color-crimson);
 	font-weight: var(--token-font-weight-normal);
 }

--- a/_includes/styles/common.css
+++ b/_includes/styles/common.css
@@ -53,6 +53,12 @@
 	border-bottom-style: none;
 }
 
+.common-link:visited,
+.common-main-content a:visited {
+	border-bottom-color: var(--token-color-gray-medium);
+	color: var(--token-color-gray-medium);
+}
+
 /* Headings */
 .common-main-content h1 {
 	/* There shouldn't be any other headings level 1 in an article/page */

--- a/_includes/styles/layout.css
+++ b/_includes/styles/layout.css
@@ -125,6 +125,7 @@
 /* Use together with .common-focus-ring */
 .layout-header__navigation__link {
 	color: var(--token-color-gray-dark);
+	padding-block: var(--token-spacing-xs);
 	text-decoration: none;
 }
 
@@ -137,7 +138,11 @@
 	width: 0;
 }
 
-.layout-header__navigation__link--active::after,
+.layout-header__navigation__link--active::after {
+	background: var(--token-color-blue);
+	width: 100%;
+}
+
 .layout-header__navigation__link:hover::after {
 	width: 100%;
 }
@@ -145,6 +150,12 @@
 /* Hide bottom outline when focus ring is visible */
 .layout-header__navigation__link:focus::after {
 	display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.layout-header__navigation__link::after {
+		transition: none;
+	}
 }
 
 /*

--- a/_includes/styles/layout.css
+++ b/_includes/styles/layout.css
@@ -138,11 +138,7 @@
 	width: 0;
 }
 
-.layout-header__navigation__link--active::after {
-	background: var(--token-color-blue);
-	width: 100%;
-}
-
+.layout-header__navigation__link--active::after,
 .layout-header__navigation__link:hover::after {
 	width: 100%;
 }

--- a/content/index.njk
+++ b/content/index.njk
@@ -1,6 +1,5 @@
 ---
 title: Blog posts
-layout: layouts/base.njk
 eleventyNavigation:
   key: Blog
   order: 2
@@ -13,8 +12,6 @@ eleventyNavigation:
 <style>
 	{{css | cssmin | safe}}
 </style>
-
-<h1>{{ title }}</h1>
 
 <p>Fresh content sorted by date, so you'll always see what's new at the top. {# Browse by categories/tags to explore topics you care about. #} You can also subscribe to the Atom feed for automatic updates.</p>
 

--- a/content/index.njk
+++ b/content/index.njk
@@ -14,11 +14,9 @@ eleventyNavigation:
 	{{css | cssmin | safe}}
 </style>
 
-<h1 class="common-main-title">{{ title }}</h1>
+<h1>{{ title }}</h1>
 
-<div class="common-main-content">
-	<p>Fresh content sorted by date, so you'll always see what's new at the top. {# Browse by categories/tags to explore topics you care about. #} You can also subscribe to the Atom feed for automatic updates.</p>
-</div>
+<p>Fresh content sorted by date, so you'll always see what's new at the top. {# Browse by categories/tags to explore topics you care about. #} You can also subscribe to the Atom feed for automatic updates.</p>
 
 <ul reversed class="archive__list">
 	{%- for post in collections.posts | reverse %}

--- a/content/index.njk
+++ b/content/index.njk
@@ -1,5 +1,6 @@
 ---
 title: Blog posts
+layout: layouts/base.njk
 eleventyNavigation:
   key: Blog
   order: 2
@@ -13,7 +14,11 @@ eleventyNavigation:
 	{{css | cssmin | safe}}
 </style>
 
-<p>Fresh content sorted by date, so you'll always see what's new at the top. {# Browse by categories/tags to explore topics you care about. #} You can also subscribe to the Atom feed for automatic updates.</p>
+<h1 class="common-main-title">{{ title }}</h1>
+
+<div class="common-main-content">
+	<p>Fresh content sorted by date, so you'll always see what's new at the top. {# Browse by categories/tags to explore topics you care about. #} You can also subscribe to the Atom feed for automatic updates.</p>
+</div>
 
 <ul reversed class="archive__list">
 	{%- for post in collections.posts | reverse %}

--- a/content/index.njk
+++ b/content/index.njk
@@ -15,7 +15,7 @@ eleventyNavigation:
 
 <p>Fresh content sorted by date, so you'll always see what's new at the top. {# Browse by categories/tags to explore topics you care about. #} You can also subscribe to the Atom feed for automatic updates.</p>
 
-<ul reversed class="archive__list">
+<ul class="archive__list">
 	{%- for post in collections.posts | reverse %}
 		<li class="archive__list-item">
 			<time class="archive__list-item__date" datetime="{{ post.date | htmlDateString }}">


### PR DESCRIPTION
This changeset includes some accessibility fixes and general clean up tasks.

## `_includes/layouts/base.njk`

- Add `aria-label="Site"` to `<nav>`
- Add `aria-current="page"` to the active nav link (alongside the existing active class)
- Add a visually hidden `<span class="visually-hidden">(external link)</span>` to the GitHub nav entry, and `target="_blank" rel="noopener noreferrer"`

## `_includes/styles/layout.css`

- Add `@media (prefers-reduced-motion: reduce)` override to disable the nav link underline transition
- Add `padding-block` to `.layout-header__navigation__link` to ensure a sufficient touch target height